### PR TITLE
chore: Ubuntu 22.04 / ROS2 Humble로 전체 환경 통일

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -11,7 +11,7 @@ jobs:
     name: colcon build 검증
     runs-on: ubuntu-22.04
     container:
-      image: ros:jazzy
+      image: ros:humble
 
     steps:
       - name: 코드 체크아웃
@@ -25,13 +25,13 @@ jobs:
 
       - name: colcon 빌드
         run: |
-          source /opt/ros/jazzy/setup.bash
+          source /opt/ros/humble/setup.bash
           colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
         shell: bash
 
       - name: 빌드 결과 확인
         run: |
-          source /opt/ros/jazzy/setup.bash
+          source /opt/ros/humble/setup.bash
           source install/setup.bash
           ros2 pkg list | grep vtol
         shell: bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 # =============================================
 # VTOL 프로젝트 통합 Docker 이미지
-# 베이스: ROS 2 Jazzy (Ubuntu 24.04)
+# 베이스: ROS 2 Humble (Ubuntu 22.04)
 # =============================================
-FROM ros:jazzy
+FROM ros:humble
 
 # 비대화형 설치
 ENV DEBIAN_FRONTEND=noninteractive
@@ -17,16 +17,16 @@ RUN apt-get update && apt-get install -y \
     wget \
     vim \
     # ROS2 패키지
-    ros-jazzy-foxglove-bridge \
-    ros-jazzy-vision-msgs \
-    ros-jazzy-tf2-ros \
-    ros-jazzy-cv-bridge \
+    ros-humble-foxglove-bridge \
+    ros-humble-vision-msgs \
+    ros-humble-tf2-ros \
+    ros-humble-cv-bridge \
     # 시리얼 통신 (아두이노)
     python3-serial \
     && rm -rf /var/lib/apt/lists/*
 
 # Python 패키지 설치
-RUN pip3 install --break-system-packages \
+RUN pip3 install \
     opencv-python \
     ultralytics \
     numpy \
@@ -39,13 +39,13 @@ RUN rosdep init || true && rosdep update
 WORKDIR /vtol_ws
 
 # ROS2 환경 자동 소싱
-RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc
+RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 RUN echo "source /vtol_ws/install/setup.bash 2>/dev/null || true" >> ~/.bashrc
 
 # 빌드
 COPY src/ /vtol_ws/src/
 RUN /bin/bash -c \
-    "source /opt/ros/jazzy/setup.bash && \
+    "source /opt/ros/humble/setup.bash && \
      rosdep install --from-paths src --ignore-src -r -y && \
      colcon build --symlink-install"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix  # GUI (Gazebo)
     network_mode: host
     command: >
-      bash -c "source /opt/ros/jazzy/setup.bash &&
+      bash -c "source /opt/ros/humble/setup.bash &&
                source /vtol_ws/install/setup.bash &&
                ros2 launch vtol_bringup sim_launch.py"
 
@@ -42,20 +42,20 @@ services:
     volumes:
       - ../src:/vtol_ws/src
     command: >
-      bash -c "source /opt/ros/jazzy/setup.bash &&
+      bash -c "source /opt/ros/humble/setup.bash &&
                source /vtol_ws/install/setup.bash &&
                ros2 launch vtol_bringup real_launch.py"
 
   # ── Foxglove 브릿지 ──
   foxglove_bridge:
-    image: ros:jazzy
+    image: ros:humble
     network_mode: host
     environment:
       - ROS_DOMAIN_ID=0
     command: >
       bash -c "apt-get update -q &&
-               apt-get install -y ros-jazzy-foxglove-bridge &&
-               source /opt/ros/jazzy/setup.bash &&
+               apt-get install -y ros-humble-foxglove-bridge &&
+               source /opt/ros/humble/setup.bash &&
                ros2 run foxglove_bridge foxglove_bridge
                --ros-args -p port:=8765"
     ports:

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # =============================================================
 # VTOL 워크스페이스 원클릭 셋업 스크립트
-# 대상 OS: Ubuntu 24.04 (ROS2 Jazzy)
+# 대상 OS: Ubuntu 22.04 (ROS2 Humble)
 # 사용법:  bash setup.sh
 # =============================================================
 set -euo pipefail
 
 VTOL_WS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROS_DISTRO="jazzy"
+ROS_DISTRO="humble"
 
 info()  { echo -e "\e[32m[INFO]\e[0m  $*"; }
 warn()  { echo -e "\e[33m[WARN]\e[0m  $*"; }
@@ -24,11 +24,11 @@ fi
 info "시스템 패키지 업데이트 중..."
 $SUDO apt-get update -qq
 
-# ── 2. ROS2 Jazzy 설치 ────────────────────────────────────────
+# ── 2. ROS2 Humble 설치 ───────────────────────────────────────
 if ! command -v ros2 &>/dev/null; then
   info "ROS2 ${ROS_DISTRO} 설치 중..."
 
-  $SUDO apt-get install -y -qq locales curl gnupg lsb-release
+  $SUDO apt-get install -y -qq locales curl gnupg2 lsb-release software-properties-common
   $SUDO locale-gen en_US en_US.UTF-8
   $SUDO update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
   export LANG=en_US.UTF-8
@@ -63,7 +63,7 @@ $SUDO apt-get install -y -qq \
 
 # ── 4. Python 패키지 ──────────────────────────────────────────
 info "Python 패키지 설치 중..."
-pip3 install --break-system-packages -q \
+pip3 install -q \
   opencv-python \
   ultralytics \
   numpy \

--- a/shell.nix
+++ b/shell.nix
@@ -27,12 +27,12 @@ pkgs.mkShell {
     echo " VTOL 개발 환경 (Nix Shell)"
     echo "──────────────────────────────────────"
 
-    # ROS2 Jazzy 소싱 (apt 설치되어 있을 경우)
-    if [ -f /opt/ros/jazzy/setup.bash ]; then
-      source /opt/ros/jazzy/setup.bash
-      echo "[OK] ROS2 Jazzy sourced"
+    # ROS2 Humble 소싱 (apt 설치되어 있을 경우)
+    if [ -f /opt/ros/humble/setup.bash ]; then
+      source /opt/ros/humble/setup.bash
+      echo "[OK] ROS2 Humble sourced"
     else
-      echo "[WARN] ROS2 Jazzy not found at /opt/ros/jazzy"
+      echo "[WARN] ROS2 Humble not found at /opt/ros/humble"
       echo "       setup.sh 를 먼저 실행하거나 Docker를 사용하세요."
     fi
 


### PR DESCRIPTION
- Dockerfile: ros:humble 베이스, ros-humble-* 패키지, pip 플래그 제거
- docker-compose.yml: 이미지 및 source 경로 humble로 수정
- .github/workflows/build_check.yml: CI 컨테이너 ros:humble로 수정
- setup.sh: ROS_DISTRO=humble, --break-system-packages 제거
- shell.nix: ROS2 Humble 소싱으로 수정

## 작업 내용
<!-- 어떤 기능을 추가/수정했는지 한두 줄로 설명 -->


## 관련 패키지 (해당하는 항목 체크)
- [ ] vtol_bringup (총괄)
- [ ] vtol_vision_yolo (비전 A)
- [ ] vtol_vision_aruco (비전 B)
- [ ] vtol_control_nav (제어 A)
- [ ] vtol_control_task (제어 B)
- [ ] vtol_hw_gripper (HW A)
- [ ] vtol_comm_lte (통신 B)
- [ ] 기타 (docker, docs, CI 등)

## 변경 유형
- [ ] 새 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서/설정 수정

## 테스트 환경
- [ ] Gazebo 시뮬레이션에서 동작 확인
- [ ] 실기체 테스트 완료
- [ ] 단위 테스트만 확인
- [ ] 해당 없음

## 스크린샷 / 로그
<!-- Foxglove 캡처, 터미널 로그, 토픽 echo 결과 등 선택 첨부 -->


## 리뷰어에게 전달 사항
<!-- 리뷰 시 특별히 봐줬으면 하는 부분, 의문점 등 -->
